### PR TITLE
Added nix flake for getting a reproducible build environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717407027,
+        "narHash": "sha256-th32FeutmKeToZRPJahopjtGecuBrBxMpXd8iLaT5i4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d96b321bccbb043cfedffc8898899f1fcb1f6437",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
+  outputs = { self, nixpkgs, ... }:
+    let
+      pkgs = nixpkgs.outputs.legacyPackages.x86_64-linux;
+      androidComposition = pkgs.androidenv.composeAndroidPackages {
+        platformVersions = [ "34" ];
+        buildToolsVersions = [ "30.0.3" ];
+        abiVersions = [ "x86" "x86_64"];
+      };
+      jdk = pkgs.jdk11;
+    in with pkgs; {
+      devShells.x86_64-linux.default = mkShell rec {
+        # nativeBuildInputs is usually what you want -- tools you need to run
+        nativeBuildInputs = [  
+          jdk
+          (callPackage gradle-packages.gradle_7 {
+            java = jdk;
+          })
+          androidComposition.androidsdk
+          androidComposition.platform-tools
+        ];
+
+        ANDROID_SDK_ROOT = "${androidComposition.androidsdk}/libexec/android-sdk";
+        ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle"; 
+        GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidComposition.androidsdk}/libexec/android-sdk/build-tools/28.0.3/aapt2 -Dorg.gradle.jvmargs=-Xmx4096M";
+      };
+    };
+}


### PR DESCRIPTION
This `flake.nix` sets up a build environment with all the necessary dependencies. To build with `nix`:
```bash
NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1 NIXPKGS_ALLOW_UNFREE=1 nix develop --impure
gradle installProductionRelease
```